### PR TITLE
Add Boilerplate Client 

### DIFF
--- a/worlds/tits_the_3rd/__init__.py
+++ b/worlds/tits_the_3rd/__init__.py
@@ -4,12 +4,25 @@ This module servies as an entrypoint into the Trails in the Sky the 3rd AP world
 from typing import ClassVar, Dict, Set
 
 from worlds.AutoWorld import WebWorld, World
+from worlds.LauncherComponents import Component, components, launch_subprocess, Type
 from .items import TitsThe3rdItem
 from .locations import create_locations as tits_the_third_create_locations
 from .options import TitsThe3rdOptions
 from .regions import create_regions as tits_the_third_create_regions
 from .settings import TitsThe3rdSettings
 from .web import TitsThe3rdWeb
+
+def launch_client():
+    """Launch a Trails in the Sky the 3rd client instance"""
+    from worlds.tits_the_3rd.client.client import launch
+    launch_subprocess(launch, name="TitsThe3rdClient")
+
+components.append(Component(
+    "Trails in the Sky the 3rd Client",
+    "TitsThe3rdClient",
+    func=launch_client,
+    component_type=Type.CLIENT
+))
 
 class TitsThe3rdWorld(World):
     """

--- a/worlds/tits_the_3rd/client/client.py
+++ b/worlds/tits_the_3rd/client/client.py
@@ -1,0 +1,64 @@
+import asyncio
+from typing import Optional
+
+import colorama
+
+from CommonClient import (
+    CommonContext,
+    get_base_parser,
+    gui_enabled,
+    server_loop,
+)
+
+class TitsThe3rdContext(CommonContext):
+    """Trails in the Sky the 3rd Context"""
+    def __init__(self, server_address: Optional[str], password: Optional[str]) -> None:
+        super().__init__(server_address, password)
+        self.game = "Trails in the Sky the 3rd"
+        self.items_handling = 0b011  # items from both your own and other worlds are sent through AP.
+
+    async def server_auth(self, password_requested: bool = False):
+        """Wrapper for login."""
+        if password_requested and not self.password:
+            await super().server_auth(password_requested)
+        await self.get_username()
+        await self.send_connect()
+
+async def tits_the_3rd_watcher(ctx: TitsThe3rdContext):
+    """
+    Client loop, watching the Trails in the Sky the 3rd game process.
+    Handles game hook attachments, checking locations, giving items, calling scena methods, etc.
+
+    Args:
+        ctx (TitsThe3rdContext): The Trails in the Sky the 3rd context instance.
+    """
+    while not ctx.exit_event.is_set():
+        await asyncio.sleep(1)
+
+def launch():
+    """
+    Launch a client instance (wrapper / args parser)
+    """
+    async def main(args):
+        """
+        Launch a client instance (threaded)
+        """
+        ctx = TitsThe3rdContext(args.connect, args.password)
+        ctx.server_task = asyncio.create_task(server_loop(ctx), name="TitsThe3rdServerLoop")
+        if gui_enabled:
+            ctx.run_gui()
+        ctx.run_cli()
+        watcher = asyncio.create_task(
+            tits_the_3rd_watcher(ctx),
+            name="TitsThe3rdProgressionWatcher"
+        )
+        await ctx.exit_event.wait()
+        await watcher
+        await ctx.shutdown()
+
+    parser = get_base_parser(description="Trails in the Sky the 3rd Client")
+    args, _ = parser.parse_known_args()
+
+    colorama.init()
+    asyncio.run(main(args))
+    colorama.deinit()


### PR DESCRIPTION
This PR adds a barebones client. It extends the python CommonClient package and allows for connecting and logging in. All implementation details specific to Trails in the Sky the 3rd are not yet implemented. This PR just adds the barebones boilerplate common to all CommonClient implementations.

### Testing
Tested by generating a game and connecting successfully.