### PR TITLE
[Issue 07][PR 1] Add prologue + ch1 items to generation

### DIFF
--- a/worlds/tits_the_3rd/__init__.py
+++ b/worlds/tits_the_3rd/__init__.py
@@ -5,7 +5,14 @@ from typing import ClassVar, Dict, Set
 
 from worlds.AutoWorld import WebWorld, World
 from worlds.LauncherComponents import Component, components, launch_subprocess, Type
-from .items import TitsThe3rdItem
+from .items import (
+    default_item_pool,
+    item_data_table,
+    item_groups,
+    item_table,
+    TitsThe3rdItem,
+    TitsThe3rdItemData,
+)
 from .locations import create_locations as tits_the_third_create_locations
 from .options import TitsThe3rdOptions
 from .regions import create_regions as tits_the_third_create_regions
@@ -40,15 +47,15 @@ class TitsThe3rdWorld(World):
     web: WebWorld = TitsThe3rdWeb()
     base_id: int = 1954308624560
 
-    item_name_groups: Dict[str, Set[str]] = {}
+    item_name_groups: Dict[str, Set[str]] = item_groups
     location_name_groups: Dict[str, Set[str]] = {}
-    item_name_to_id: Dict[str, int] = {"Dummy Item": base_id}
+    item_name_to_id: Dict[str, int] = item_table
     location_name_to_id: Dict[str, int] = {"Dummy Location": base_id}
 
     def create_item(self, name: str) -> TitsThe3rdItem:
         """Create a Trails in the Sky the 3rd item for this player"""
-        item_classification = TitsThe3rdItem.get_item_classfication(name)
-        return TitsThe3rdItem(name, item_classification, self.item_name_to_id[name], self.player)
+        data: TitsThe3rdItemData = item_data_table[name]
+        return TitsThe3rdItem(name, data.classification, data.code, self.player)
 
     def create_event(self, name: str) -> TitsThe3rdItem:
         """Create a Trails in the Sky the 3rd event for this player"""
@@ -61,10 +68,10 @@ class TitsThe3rdWorld(World):
 
     def create_items(self) -> None:
         """Define items for Trails in the Sky the 3rd AP"""
-        dummy_item = self.create_item("Dummy Item")
-        self.multiworld.itempool.append(dummy_item)
+        for item_name, quantity in default_item_pool.items():
+            for _ in range(quantity):
+                self.multiworld.itempool.append(self.create_item(item_name))
 
     def set_rules(self) -> None:
         """Set remaining rules."""
-        self.multiworld.completion_condition[self.player] = \
-            lambda state: state.has("Dummy Item", self.player)
+        self.multiworld.completion_condition[self.player] = lambda _: True

--- a/worlds/tits_the_3rd/items.py
+++ b/worlds/tits_the_3rd/items.py
@@ -1,18 +1,87 @@
 """This module represents item definitions for Trails in the Sky the 3rd"""
+from typing import Dict, NamedTuple, Optional, Set
+
+from .names.item_name import ItemName
 from BaseClasses import Item, ItemClassification
 
 class TitsThe3rdItem(Item):
     """Trails in the Sky the 3rd Item Definition"""
     game: str = "Trails in the Sky the 3rd"
 
-    @staticmethod
-    def get_item_classfication(name: str):
-        """
-        Returns the item classification based on the name of the item
+    def __init__(self, name, classification: ItemClassification, code: Optional[int], player: int):
+        super(TitsThe3rdItem, self).__init__(name, classification, code, player)
 
-        Args:
-            name (str): The name of the item
-        """
-        # TODO: determine item classification (In the meantime this method will always return filler)
-        return ItemClassification.filler
+class TitsThe3rdItemData(NamedTuple):
+    """Trails in the Sky the 3rd Item Data"""
+    code: int
+    classification: ItemClassification
 
+consumable_table: Dict[str, TitsThe3rdItemData] = {
+    ItemName.extra_spicy_fries: TitsThe3rdItemData(408, ItemClassification.filler),
+    ItemName.fresh_water: TitsThe3rdItemData(411, ItemClassification.filler),
+    ItemName.fishy_finale: TitsThe3rdItemData(437, ItemClassification.filler),
+    ItemName.tear_balm: TitsThe3rdItemData(501, ItemClassification.filler),
+    ItemName.teara_balm: TitsThe3rdItemData(502, ItemClassification.filler),
+    ItemName.reviving_balm: TitsThe3rdItemData(508, ItemClassification.filler),
+    ItemName.ep_charge: TitsThe3rdItemData(510, ItemClassification.filler),
+    ItemName.smelling_salts: TitsThe3rdItemData(512, ItemClassification.filler),
+}
+
+recipe_table: Dict[str, TitsThe3rdItemData] = {
+    ItemName.easy_paella_recipe: TitsThe3rdItemData(10000, ItemClassification.filler),
+}
+
+equipment_table: Dict[str, TitsThe3rdItemData] = {
+    ItemName.royal_spikes: TitsThe3rdItemData(102, ItemClassification.useful),
+    ItemName.black_bangle: TitsThe3rdItemData(356, ItemClassification.useful),
+    ItemName.glam_choker: TitsThe3rdItemData(358, ItemClassification.useful),
+}
+
+quartz_table: Dict[str, TitsThe3rdItemData] = {
+    ItemName.hit_2: TitsThe3rdItemData(619, ItemClassification.useful),
+    ItemName.information: TitsThe3rdItemData(657, ItemClassification.useful),
+}
+
+currency_table: Dict[str, TitsThe3rdItemData] = {
+    ItemName.mira_300: TitsThe3rdItemData(20000, ItemClassification.filler),
+    ItemName.lower_elements_sepith_50: TitsThe3rdItemData(20001, ItemClassification.filler),
+    ItemName.higher_elements_sepith_50: TitsThe3rdItemData(20002, ItemClassification.filler),
+}
+
+item_data_table: Dict[str, TitsThe3rdItemData] = {
+    **consumable_table,
+    **recipe_table,
+    **equipment_table,
+    **quartz_table,
+    **currency_table,
+}
+
+item_groups: Dict[str, Set[str]] = {
+    "Consumables": set(consumable_table.keys()),
+    "Recipes": set(recipe_table.keys()),
+    "Equipment": set(equipment_table.keys()),
+    "Quartz": set(quartz_table.keys()),
+    "Currency": set(currency_table.keys()),
+}
+
+item_table: Dict[str, int] = {name: data.code for name, data in item_data_table.items()}
+
+default_item_pool: Dict[str, int] = {
+    ItemName.extra_spicy_fries: 1, # Default locations: 9864
+    ItemName.fresh_water: 1, # Default locations: 9880
+    ItemName.fishy_finale: 1, # Default locations: 9884
+    ItemName.tear_balm: 2, # Default locations: 9858, 9865
+    ItemName.teara_balm: 2, # Default locations: 9720, 9722
+    ItemName.reviving_balm: 1, # Default locations: 9874
+    ItemName.ep_charge: 2, # Default locations: 9721, 9723
+    ItemName.smelling_salts: 1, # Default locations: 9866
+    ItemName.easy_paella_recipe: 1, # Default locations: 9873
+    ItemName.royal_spikes: 1, # Default locations: 9869
+    ItemName.black_bangle: 1, # Default locations: 9867
+    ItemName.glam_choker: 1, # Default locations: 9868
+    ItemName.hit_2: 1, # Default locations: 9872
+    ItemName.information: 1, # Default locations: 9857
+    ItemName.mira_300: 2, # Default locations: 9859, 9875
+    ItemName.lower_elements_sepith_50: 1, # Default locations: 9881
+    ItemName.higher_elements_sepith_50: 1, # Default locations: 9885
+}

--- a/worlds/tits_the_3rd/names/item_name.py
+++ b/worlds/tits_the_3rd/names/item_name.py
@@ -1,10 +1,9 @@
 """
-Const item names.
+Constants for item names.
 """
 
-# pylint: disable=invalid-name
-
 class ItemName:
+    """Constants for item names."""
     # Consumables
     extra_spicy_fries = "Extra Spicy Fries"
     fresh_water = "Fresh Water"

--- a/worlds/tits_the_3rd/names/item_name.py
+++ b/worlds/tits_the_3rd/names/item_name.py
@@ -1,0 +1,33 @@
+"""
+Const item names.
+"""
+
+# pylint: disable=invalid-name
+
+class ItemName:
+    # Consumables
+    extra_spicy_fries = "Extra Spicy Fries"
+    fresh_water = "Fresh Water"
+    fishy_finale = "Fishy Finale"
+    tear_balm = "Tear Balm"
+    teara_balm = "Teara Balm"
+    reviving_balm = "Reviving Balm"
+    ep_charge = "EP Charge"
+    smelling_salts = "Smelling Salts"
+
+    # Recipes
+    easy_paella_recipe = "Easy Paella Recipe"
+
+    # Equipment
+    royal_spikes = "Royal Spikes"
+    black_bangle = "Black Bangle"
+    glam_choker = "Glam Choker"
+
+    # Quartz
+    hit_2 = "Hit 2"
+    information = "Information"
+
+    # Currency
+    mira_300 = "Mira (300)"
+    lower_elements_sepith_50 = "Lower Elements Sepith (50)"
+    higher_elements_sepith_50 = "Higher Elements Sepith (50)"


### PR DESCRIPTION
# Summary
This PR adds the chest items for Prologue / Ch1 for a POC. AP Item IDs by default match the in-game item ID if it exists.

Modeled after https://github.com/tdkollins/Archipelago-Rabi-Ribi/tree/main/worlds/rabi_ribi

# Testing
- [x] Tested a generation