### PR TITLE
Issue 16/dev util works with latest factoria release

### DIFF
--- a/worlds/tits_the_3rd/dev_util/readme.md
+++ b/worlds/tits_the_3rd/dev_util/readme.md
@@ -6,7 +6,7 @@ Before running these scripts, please modify `dev_config.json` in this directory 
 - gameDirectory: This should point to your TitS the 3rd installation root. This root should contain the unmodified `ED6_DTXX` files from your game download.
 - lbARKDirectory: This should point to your [LB-ARK installation](https://github.com/Aureole-Suite/LB-ARK). This is by default `"C:\\Program Files (x86)\\Steam\\steamapps\\common\\Trails in the Sky the 3rd\\data"`
 
-Afterwards, please download both [calmare.exe](https://github.com/Kyuuhachi/Aureole/releases/tag/factoria-v1.1.0) and [factoria.exe](https://github.com/Kyuuhachi/Aureole/releases/tag/factoria-v1.1.0) and place them within the `worlds/tits_the_third/external_tools` directory.
+Afterwards, please download both [calmare.exe](https://github.com/Kyuuhachi/Aureole/releases/tag/calmare-v0.1.3) and [factoria.exe](https://github.com/Aureole-Suite/Factoria/releases/tag/v1.0) and place them within the `worlds/tits_the_third/external_tools` directory.
 
 ## patch.py
 

--- a/worlds/tits_the_3rd/patch/patch.py
+++ b/worlds/tits_the_3rd/patch/patch.py
@@ -110,12 +110,13 @@ def _decompress_with_factoria(temp_dir: str, source_dir: str):
             file_path = f"{base_file_path}{extention}"
             if not os.path.exists(file_path):
                 raise ValueError(f"Path {file_path} does not exist.")
+        os.makedirs(os.path.join(temp_dir, filename))
         try:
             subprocess.run([
                 factoria_path,
                 f"{base_file_path}.dir",
                 "--output",
-                temp_dir
+                os.path.join(temp_dir, filename)
             ], check=True)
         except subprocess.CalledProcessError as err:
             print(f"Error running factoria: {err}")


### PR DESCRIPTION
- Resolves #16 

New factoria release modified the output to decompress by default, which we don't want.

There was an argument to compress... it seemed to parse arguments weirdly (e.g. going --compressed true would interpret true as a path to process, but --compressed would not compress). To work around this I just manually created the compress folder to dump the output into, without using the argument.