### PR TITLE
Detect if the player is on the correct save

### DIFF
--- a/worlds/tits_the_3rd/client/client.py
+++ b/worlds/tits_the_3rd/client/client.py
@@ -1,4 +1,6 @@
 import asyncio
+import hashlib
+import time
 from typing import Optional
 
 import colorama
@@ -19,6 +21,13 @@ class TitsThe3rdContext(CommonContext):
         self.game = "Trails in the Sky the 3rd"
         self.items_handling = 0b011  # items from both your own and other worlds are sent through AP.
         self.game_interface = TitsThe3rdMemoryIO(self.exit_event)
+        self.world_player_identifier: bytes = b"\x00\x00\x00\x00"
+
+    def reset_client_state(self):
+        """
+        Resets the client state to the initial state.
+        """
+        self.world_player_identifier = b"\x00\x00\x00\x00"
 
     async def server_auth(self, password_requested: bool = False):
         """Wrapper for login."""
@@ -26,6 +35,46 @@ class TitsThe3rdContext(CommonContext):
             await super().server_auth(password_requested)
         await self.get_username()
         await self.send_connect()
+
+    def on_package(self, cmd: str, args: dict):
+        if cmd == "Connected":
+            # if we dont have the seed name from the RoomInfo packet, wait until we do.
+            while not self.seed_name:
+                time.sleep(1)
+            # Hash the seed name + player name and take the first 4 bytes as the world player identifier.
+            self.world_player_identifier = f"{self.seed_name}-{self.auth}"
+            self.world_player_identifier = (hashlib.sha256(self.world_player_identifier.encode()).digest())[:4]
+        if cmd == "RoomInfo":
+            self.seed_name = args["seed_name"]
+
+    def client_recieved_initial_server_data(self):
+        """
+        This returns true if the client has finished the initial conversation with the server.
+        This means:
+            - Authenticated with the server (self.auth is set)
+            - RoomInfo package recieved (self.seed_name is set)
+            - World player identifier is calculated based on the seed and player name (self.world_player_identifier is set)
+        """
+        return (
+            self.auth and
+            self.seed_name and
+            self.world_player_identifier
+        )
+
+    async def wait_for_ap_connection(self):
+        """
+        This method waits until the client finishes the initial connection with the server.
+        See client_recieved_initial_server_data for wait requirements
+        """
+        if self.client_recieved_initial_server_data():
+            return
+        logger.info("Waiting for connect from server...")
+        while not self.client_recieved_initial_server_data() and not self.exit_event.is_set():
+            await asyncio.sleep(1)
+        if not self.exit_event.is_set():
+            # wait an extra second to process data
+            await asyncio.sleep(1)
+            logger.info("Received initial data from server!")
 
 async def tits_the_3rd_watcher(ctx: TitsThe3rdContext):
     """
@@ -35,11 +84,24 @@ async def tits_the_3rd_watcher(ctx: TitsThe3rdContext):
     Args:
         ctx (TitsThe3rdContext): The Trails in the Sky the 3rd context instance.
     """
+    await ctx.wait_for_ap_connection()
     while not ctx.exit_event.is_set():
+        await asyncio.sleep(1)
+
+        if not ctx.server:
+            # client disconnected from server
+            ctx.reset_client_state()
+            await ctx.wait_for_ap_connection()
+            continue
+
         if not ctx.game_interface.is_connected():
             logger.info("Waiting for connection to Trails in the Sky The Third")
             await ctx.game_interface.connect()
-        await asyncio.sleep(1)
+            continue
+
+        if ctx.game_interface.should_write_world_player_identifier():
+            ctx.game_interface.write_world_player_identifier(ctx.world_player_identifier)
+            continue
 
 def launch():
     """


### PR DESCRIPTION
- Resolves #8 

### Summary
Detect if the player is on the correct save before performing any AP operations. This is done by:
1. Using a flag set on new game which indicates "should write ID".
2. Calculating a unique ID based on the seed and player name on AP room connection.
3. If the flag is set, write the unique ID into flag data and wipe the flag. This will persist for the entirety of the save data.
4. Otherwise, assert that the unique ID in memory matches the calculated ID before performing any AP ops.

### Testing
- [x] Ran locally against 2 players and confirmed everything works as intended. 