### PR TITLE
Fix bug where gen uses player id for item requirement quantity

### DIFF
--- a/worlds/tits_the_3rd/crafts/craft_randomizer.py
+++ b/worlds/tits_the_3rd/crafts/craft_randomizer.py
@@ -25,8 +25,9 @@ def _get_character_to_craft_get_order() -> dict[str, List[Dict[int, int]]]:
     The order of the craft_id is the default order based on level acquired.
     This will return the character's default crafts.
     """
+    default_characters_copy = deepcopy(default_characters)
     character_to_craft_get_order = {}
-    for character in default_characters:
+    for character in default_characters_copy:
         craft_id_to_level_acquired = {}
         crafts = character.crafts
 
@@ -142,9 +143,10 @@ def _get_old_craft_id_to_new_craft_id(characters: List[Character]) -> Dict[int, 
     Returns:
         Dict[int, int]: A mapping of old craft IDs to new craft IDs.
     """
+    default_characters_copy = deepcopy(default_characters)
     old_craft_id_to_new_craft_id = {}
     for idx, character in enumerate(characters):
-        default_character = default_characters[idx]
+        default_character = default_characters_copy[idx]
         for idx, old_craft in enumerate(default_character.fixed_normal_crafts):
             old_craft_id_to_new_craft_id[old_craft.base_craft_id] = character.fixed_normal_crafts[idx].base_craft_id
         for idx, old_craft in enumerate(default_character.fixed_scrafts):

--- a/worlds/tits_the_3rd/locations.py
+++ b/worlds/tits_the_3rd/locations.py
@@ -77,7 +77,7 @@ def create_locations(multiworld: MultiWorld, player: int, options: TitsThe3rdOpt
         rule = None
         if location_table[location_name].item_requirements:
             rule = lambda state, loc_name=location_name: all(
-                state.has(scrub_spoiler_data(item_name) if options.name_spoiler_option else item_name, quantity, player)
+                state.has(scrub_spoiler_data(item_name) if options.name_spoiler_option else item_name, player, quantity)
                 for item_name, quantity in location_table[loc_name].item_requirements
             )
         create_location(multiworld, player, location_name, options, rule)


### PR DESCRIPTION
state.has arguments were accidentally swapped, so it was providing the quantity of the item needed with the player id (and vice versa)