### PR TITLE
Add option to offset the level crafts are unlocked

### DIFF
--- a/worlds/tits_the_3rd/__init__.py
+++ b/worlds/tits_the_3rd/__init__.py
@@ -316,6 +316,7 @@ class TitsThe3rdWorld(World):
             "default_crfget": self.options.craft_placement == CraftPlacement.option_default and not self.options.craft_shuffle,
             "victory_location": self.get_victory_item_and_location()[1],
             "weapon_shuffle": self.options.weapon_shuffle.value,
+            "craft_level_offset": self.options.craft_level_offset.value,
         }
 
     def get_filler_item_name(self):

--- a/worlds/tits_the_3rd/client/client.py
+++ b/worlds/tits_the_3rd/client/client.py
@@ -651,7 +651,8 @@ class TitsThe3rdContext(CommonContext):
                 character_id, level_threshold = craft_location_id_to_character_id_and_level_threshold[location_id]
                 if not self.game_interface.has_character(character_id):
                     continue
-                if self.game_interface.read_character_level(character_id) >= level_threshold:
+                level_offset = self.slot_data["craft_level_offset"]
+                if self.game_interface.read_character_level(character_id) >= (level_threshold + level_offset):
                     await self.check_location(location_id)
                     continue
             elif MIN_CRAFT_LOCATION_ID <= location_id <= MAX_CRAFT_LOCATION_ID and location_id in event_craft_location_id_to_character_id_and_craft_id:

--- a/worlds/tits_the_3rd/options.py
+++ b/worlds/tits_the_3rd/options.py
@@ -1,7 +1,7 @@
 """This module represents options definitions for Trails in the Sky the 3rd"""
 from dataclasses import dataclass
 
-from Options import Choice, DefaultOnToggle, PerGameCommonOptions, Toggle, Visibility
+from Options import Choice, DefaultOnToggle, PerGameCommonOptions, Toggle, Visibility, Range
 
 
 class NameSpoilerOption(Toggle):
@@ -141,6 +141,19 @@ class CraftPlacement(Choice):
     option_crafts = 1
     option_anywhere = 2
 
+class CraftLevelOffset(Range):
+    """
+    Level offset applied to craft unlocks. For example, if set to -2, you will receive
+    all crafts 2 levels earlier that you would otherwise. This reduces grinding.
+
+    Modifying this option to extreme amounts may lead to out of logic location checks.
+    This is because logic assumes that you will get crafts at their default level.
+    """
+    display_name = "Craft Level Offset"
+    default = 0
+    range_start = -50
+    range_end = 0
+
 class WeaponShuffle(Toggle):
     """
     Shuffle Weapon unlocks into the item pool.
@@ -163,3 +176,4 @@ class TitsThe3rdOptions(PerGameCommonOptions):
     craft_shuffle: CraftShuffle
     craft_placement: CraftPlacement
     weapon_shuffle: WeaponShuffle
+    craft_level_offset: CraftLevelOffset

--- a/worlds/tits_the_3rd/tables/location_list.py
+++ b/worlds/tits_the_3rd/tables/location_list.py
@@ -668,7 +668,7 @@ for craft in craft_locations:
     character_id = character_name_to_id[character_name]
     level_match = re.search(r'\(Level (\d+)\)', craft)
     if level_match:
-        level_threshold = int(level_match.group(1)) - 2
+        level_threshold = int(level_match.group(1))
         craft_location_id_to_character_id_and_level_threshold[craft_locations[craft].flag] = (character_id, level_threshold)
     else:
         craft_name = craft.split(" - ", 1)[1]


### PR DESCRIPTION
This PR adds an option to modify what level crafts are unlocked. For example, you can offset all crafts to be unlocked 2 levels earlier.